### PR TITLE
feat: Added  to command log for easier debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,21 +36,21 @@ This library is a proof of concept, but should be stable. The proposal can be fo
 Synchronous functions can be retried, async functions cannot. Retrying allows implicit waiting which avoids confusing flaky failures where tests are dependant on timing.
 
 ```ts
-// okay
-// The `cy.*` command inside the function prevents automatic retries. The following will actually fail if `#first` isn't immediately available in the DOM
+// bad
+// The `cy.*` command inside the function prevents automatic retries. The following will actually fail if the text `'foobar'` isn't immediately available in the DOM
 const getFirst = $el => cy.wrap($el).find('#first')
 
 cy.get('body')
   .pipe(getFirst)
-  .should('have.id', 'first')
+  .should('contain', 'foobar')
 
-// best
-// synchronous resolution - pipe will retry `getFirst` until it returns a non-empty jQuery element list
+// good
+// synchronous resolution - pipe will retry `getFirst` until it returns a non-empty jQuery element list and contains the text 'foobar'
 const getFirst = $el => $el.find('#first')
 
 cy.get('body')
   .pipe(getFirst)
-  .should('have.id', 'first')
+  .should('contain', 'foobar')
 ```
 
 ### Use cy commands for actions
@@ -99,7 +99,7 @@ cy.wrap({ foo: 'bar' })
 If you have a function that returns another function (curried for extra input), name that.
 ```ts
 // Name the returned curried function
-const getProp = key => function getFoo(s) {
+const getProp = key => function getProp(s) {
   return s[key]
 }
 

--- a/cypress/integration/example_spec.js
+++ b/cypress/integration/example_spec.js
@@ -74,14 +74,28 @@ describe('pipe()', () => {
   
       it('should have the correct element in the Command Log', () => {
         let lastLog
+
         cy.on('log:added', (attrs, log) => {
           if (log.get('name') === 'pipe') {
-            cy.removeAllListeners('log:added')
-
             lastLog = log
           }
         })
 
+        cy.get('body')
+          .pipe(getFirst)
+          .should(() => {
+            expect(lastLog.get('$el')).to.have.attr('id', 'first')
+          })
+      })
+
+      it('should have the correct consoleProps', () => {
+        let lastLog
+        cy.on('log:added', (attrs, log) => {
+          if (log.get('name') === 'pipe') {
+            lastLog = log
+          }
+        })
+        
         cy.get('body')
           .pipe(getFirst)
           .should(() => {
@@ -156,25 +170,46 @@ describe('pipe()', () => {
       })
 
       it('should have the correct element in the Command Log', () => {
-        let firstLog
+        // This test is a little strange since snapshots show what element
+        // is selected, but snapshots themselves don't give access to those
+        // elements. I had to make the implementation specific so that the `$el`
+        // is the `subject` when the log is added and the `$el` is the `value`
+        // when the log is changed. It would be better to extract the `$el` from
+        // each snapshot
         cy.on('log:added', (attrs, log) => {
           if (log.get('name') === 'pipe') {
-            cy.removeAllListeners('log:added')
+            expect(log.get('$el')).to.have.prop('tagName', 'BODY')
+          }
+        })
 
-            firstLog = log
+        cy.on('log:changed', (attrs, log) => {
+          if (log.get('name') === 'pipe') {
+            expect(log.get('$el')).to.have.attr('id', 'first')
           }
         })
 
         cy.get('body')
           .pipe(getFirst)
+      })
+
+      it('should have the correct consoleProps', () => {
+        let lastLog
+        cy.on('log:added', (attrs, log) => {
+          if (log.get('name') === 'pipe') {
+            lastLog = log
+          }
+        })
+        
+        cy.get('body')
+          .pipe(getFirst)
           .should(() => {
-            const consoleProps = firstLog.invoke('consoleProps')
+            const consoleProps = lastLog.invoke('consoleProps')
 
             expect(consoleProps).to.have.property('Elements', 1)
             expect(consoleProps.Yielded).to.have.id('first')
           })
       })
-
+      
       it('should wait to continue for each step and resolve the chain with the correct value', () => {
         cy.get('body')
           .pipe(getFirst)
@@ -187,8 +222,6 @@ describe('pipe()', () => {
         let lastLog
         cy.on('log:added', (attrs, log) => {
           if (log.get('name') === 'pipe') {
-            cy.removeAllListeners('log:added')
-
             lastLog = log
           }
         })

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,8 +8,10 @@ declare namespace Cypress {
      * many times per second.
      * 
      * ```ts
+     * const getChildren = $el => $el.children()
+     * 
      * cy.get('body')
-     *   .pipe($body => $body.children())
+     *   .pipe(getChildren)
      *   .should('have.length', 3)
      * ```
      */

--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
   <div id="first"></div>
   <button id="remove" type="button">Remove</button>
   <script>
-    var delay = 1000
+    var delay = 100
     // create asynchronous loading of elements
     setTimeout(() => {
       document.querySelector('#first').innerHTML = '<div id="second"></div>'


### PR DESCRIPTION
The screenshot shows the `after` snapshot that has the element set to the `#first` div.

![screen shot 2018-10-23 at 4 01 33 pm](https://user-images.githubusercontent.com/338257/47393560-1a2be180-d6dd-11e8-98e4-2884f7bf3379.png)

If the function is pure and returns an element, the returned element will be used as the Element in the Command Log

If the function uses Cypress commands, the `before` snapshot will have the passed in `subject` as the Element. The `after` snapshot will have the wrapped `value` returned by the the function as the Element in the Command Log.