### PR TITLE
fix: remove hard-coded timeout to use config timeout

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,10 +31,6 @@ Cypress.Commands.add('pipe', { prevSubject: true }, (subject, fn, options = { lo
     })
   }
 
-  Cypress._.defaults(options, {
-    timeout: 4000,
-  })
-
   const getConsoleProps = (value) => () => ({
     Command: 'pipe',
     Subject: subject,


### PR DESCRIPTION
Remove the hard-coded timeout which accidentally overrides the default timeout configured through the `cypress.json` file.