### PR TITLE
fix: Still log even if timeout is supplied

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,12 +17,16 @@ const getElements = $el => {
   }
 }
 
-Cypress.Commands.add('pipe', { prevSubject: true }, (subject, fn, options = { log: true }) => {
+Cypress.Commands.add('pipe', { prevSubject: true }, (subject, fn, options = { }) => {
 
   const getEl = (value) => isJquery(value) ? value : isJquery(subject) ? subject : undefined
 
   const now = performance.now()
   let isCy = false
+  
+  Cypress._.defaults(options, {
+    timeout: 4000,
+  })
 
   if (options.log) {
     options._log = Cypress.log({


### PR DESCRIPTION
If a `timeout` is supplied but not a `log: true`, pipe won't log.