### PR TITLE
feat: Loggable decorator for piped functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,31 @@ WRAP       {foo: bar}
 
 If the `pipe` was using a `then`, it would fail immediately and wouldn't show the `getFoo` functions anywhere in the Cypress Command Log.
 
+If you care even more about log output and you have more generic functions that curry other functions, you can use `loggable`. That sounds scary, but you might have a function like `getTodoByName` where the function takes the name of the Todo and returns a function that takes a container. For example:
+
+```ts
+import { loggable } from 'cypress-pipe'
+
+const getProp = loggable('getProp', prop => obj => obj[prop])
+// alternative
+const getProp = loggable(prop => function getProp(obj) { return obj[prop] })
+
+cy.wrap({ foo: 'bar' })
+  .pipe(getProp('foo'))
+  .should('equal', 'bar')
+```
+
+The `loggable` decorator function can either take a `name` as a string, or allow `.pipe` to get it from a named currried function.
+
+The Cypress Log will look like:
+
+```
+WRAP       {foo: bar}
+ - PIPE    getProp("foo")
+ - ASSERT  expected bar to equal bar
+```
+
+
 This library is a proof of concept, but should be stable. The proposal can be found here: https://github.com/cypress-io/cypress/issues/1548
 
 ## Best Practices

--- a/index.js
+++ b/index.js
@@ -17,6 +17,19 @@ const getElements = $el => {
   }
 }
 
+/**
+ * Format the argument according to its type
+ * @param {any} arg 
+ */
+function formatArg (arg) {
+  switch (typeof arg) {
+    case 'function':
+      return arg.name || 'function'
+    default:
+      return JSON.stringify(arg)
+  }
+}
+
 Cypress.Commands.add('pipe', { prevSubject: true }, (subject, fn, options = { }) => {
 
   const getEl = (value) => isJquery(value) ? value : isJquery(subject) ? subject : undefined
@@ -31,7 +44,7 @@ Cypress.Commands.add('pipe', { prevSubject: true }, (subject, fn, options = { })
 
   if (options.log) {
     options._log = Cypress.log({
-      message: fn.name || undefined,
+      message: (fn.displayName || fn.name || undefined) + (fn.__args ? `(${fn.__args.map(formatArg).join(', ')})` : ''),
       $el: getEl(subject), // start the $el with the subject
     })
   }
@@ -39,8 +52,9 @@ Cypress.Commands.add('pipe', { prevSubject: true }, (subject, fn, options = { })
   const getConsoleProps = (value) => () => ({
     Command: 'pipe',
     Subject: subject,
-    Message: fn.name || undefined,
-    Function: fn.toString(),
+    Function: fn.displayName || fn.name || undefined,
+    Arguments: fn.__args || [],
+    Contents: fn.toString(),
     Yielded: isJquery(value) ? getElements(value) : value,
     Elements: isJquery(value) ? value.length : undefined,
     Duration: performance.now() - now,

--- a/loggable.d.ts
+++ b/loggable.d.ts
@@ -1,0 +1,20 @@
+/**
+ * Decorate a function with meta-data to be used with `cy.pipe`. Adds
+ * a display name and arguments of a function.
+ * @param name The name of the function to be displayed in the Cypress
+ * Command Log. The parameter is only required if the function passed
+ * to `cy.pipe` is anonymous
+ * @param fn Function to decorate
+ * @example
+ * const getProp = loggable('getProp', prop => obj => obj[prop])
+ */
+export function loggable<T extends Function>(name: string, fn: T): T
+
+/**
+ * Decorate a function with meta-data to be used with `cy.pipe`. Adds
+ * arguments of a function.
+ * @param fn Function to decorate
+ * @example
+ * const getProp = loggable(prop => function getProp(obj) { return obj[prop] })
+ */
+export function loggable<T extends Function>(fn: T): T

--- a/loggable.js
+++ b/loggable.js
@@ -1,0 +1,26 @@
+function loggable(arg1, arg2) {
+  if (typeof arg1 === 'string') {
+    arg2.displayName = arg1
+    return loggableFn(arg2)
+  } else if (typeof arg1 === 'function') {
+    return loggableFn(arg1)
+  } else {
+    throw Error('First argument must be a function or string')
+  }
+}
+
+function loggableFn(fn) {
+  const internalFn = function(...args) {
+    const value = fn(...args)
+    if (typeof value === 'function') {
+      value.displayName = fn.displayName || value.name
+      value.__args = args
+    }
+    return value
+  }
+  internalFn.displayName = fn.displayName || fn.name
+
+  return internalFn
+}
+
+module.exports = { loggable }


### PR DESCRIPTION
`loggable` attaches additional metadata to helper functions for the `.pipe` Command. This includes ensuring the display name of a function regardless of the function being anonymous and also attaches parameters passed.

Example:
```ts
const getProp = loggable('getProp', prop => obj => obj[prop]
cy.wrap({ foo: 'bar'  })
  .pipe(getProp('foo'))
  .should('equal', 'bar')
```

This will show the following in the the Cypress Command Log:
```
WRAP      {foo: bar}
- PIPE    getProp("foo")
- ASSERT  expected bar to equal bar
```

Without using `loggable`, the `PIPE` line would not include arguments passed to `getProp`:
```
- PIPE   getProp
```

Fixes #16