### PR TITLE
Adding null as an allowed type for S

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,10 +8,10 @@ declare namespace Cypress {
      * a `.should` AND returns a value synchronously (no `cy` commands inside).
      * In this instance, your function should not have any side effects and could be run
      * many times per second.
-     * 
+     *
      * ```ts
      * const getChildren = $el => $el.children()
-     * 
+     *
      * cy.get('body')
      *   .pipe(getChildren)
      *   .should('have.length', 3)
@@ -21,7 +21,7 @@ declare namespace Cypress {
       fn: (this: { [key: string]: any }, currentSubject: Subject) => Chainable<S> | Promise<S>,
       options?: Partial<Timeoutable & Loggable>,
     ): Chainable<S>
-    pipe<S extends object | any[] | string | number | boolean | undefined>(
+    pipe<S extends object | any[] | string | number | boolean | undefined | null>(
       fn: (this: { [key: string]: any }, currentSubject: Subject) => S,
       options?: Partial<Timeoutable & Loggable>,
     ): Chainable<S>


### PR DESCRIPTION
Hello,

I have run into the following situation where I need S to also include null in the type it extends.

I was able to work around it in code like this:
```typescript
export const useSelector = <
  T,
  R extends string | number | boolean | object | any[] | undefined | null
>(
  [selector, ...args]: [(state: IState, ...args: T[]) => R, ...T[]],
  shouldLambda?: (value: R) => void,
) =>
  cy
    .window()
    .pipe<{ value: R }>(win => {
      const state: IState = win.store.getState();
      // having to wrap this selector result in an object to appease
      // the return type of the lambda passed to pipe as null is not allowed
      return { value: selector(state, ...args) };
    })
    .should(({ value }) => shouldLambda && shouldLambda(value));
```

but after looking at the code, I didn't see an issue with S being modified to allow null as a value. It would simplify this code above so that I don't have to wrap the result in an object.

Thoughts?