### PR TITLE
feat: Add parent command ability

### DIFF
--- a/cypress/integration/example_spec.js
+++ b/cypress/integration/example_spec.js
@@ -8,7 +8,7 @@ const delay = 100 // delay of some retries. Make this larger if you want to see 
 describe('loggable', () => {
   context('when only a function is provided', () => {
     it('should set __args to equal arguments passed in', () => {
-      const getProp = loggable(prop => obj => obj[prop])
+      const getProp = loggable((prop, num, bool) => obj => obj[prop])
       const fn = getProp('foo', 1, false)
       expect(fn.__args).to.deep.equal(['foo', 1, false])
     })
@@ -157,8 +157,11 @@ describe('pipe()', () => {
     })
 
     context('when visiting a page', () => {
+      /** @param $el {JQuery} */
       const getFirst = $el => $el.find('#first')
+      /** @param $el {JQuery} */
       const getSecond = $el => $el.find('#second')
+      /** @param $el {JQuery} */
       const getText = $el => $el.text()
 
       beforeEach(() => {
@@ -252,6 +255,12 @@ describe('pipe()', () => {
               expect(lastLog.get('snapshots')).to.have.length(1)
             }
           })
+      })
+
+      it('should use the body tag if no previous subject was provided', () => {
+        cy.pipe(getFirst)
+          .pipe(getSecond)
+          .should('contain', 'foobar')
       })
     })
   })

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,11 +10,17 @@ declare global {
        * In this instance, your function should not have any side effects and could be run
        * many times per second.
        *
+       * It can start a chain or continue a chain. If starting a chain, the subject
+       * will be the body elememnt
+       *
        * ```ts
        * const getChildren = $el => $el.children()
        *
        * cy.get('body')
        *   .pipe(getChildren)
+       *   .should('have.length', 3)
+       *
+       * cy.pipe(getChildren) // $el will be body
        *   .should('have.length', 3)
        * ```
        */
@@ -22,8 +28,47 @@ declare global {
         fn: (this: { [key: string]: any }, currentSubject: Subject) => Chainable<S> | Promise<S>,
         options?: Partial<Timeoutable & Loggable>,
       ): Chainable<S>
+      /**
+       * Enables you to work with the subject yielded from the previous command.
+       * Similar to `cy.then`, except the function can be re-evaluated if followed by
+       * a `.should` AND returns a value synchronously (no `cy` commands inside).
+       * In this instance, your function should not have any side effects and could be run
+       * many times per second.
+       *
+       * It can start a chain or continue a chain. If starting a chain, the subject
+       * will be the body elememnt
+       *
+       * ```ts
+       * const getChildren = $el => $el.children()
+       *
+       * cy.get('body')
+       *   .pipe(getChildren)
+       *   .should('have.length', 3)
+       *
+       * cy.pipe(getChildren) // $el will be body
+       *   .should('have.length', 3)
+       * ```
+       */
       pipe<S extends object | any[] | string | number | boolean | undefined | null>(
         fn: (this: { [key: string]: any }, currentSubject: Subject) => S,
+        options?: Partial<Timeoutable & Loggable>,
+      ): Chainable<S>
+      /**
+       * Starts a chain. The subject is the jQuery-wrapped body element is given to the function.
+       * Similar to `cy.then`, except the function can be re-evaluated if followed by
+       * a `.should` AND returns a value synchronously (no `cy` commands inside).
+       * In this instance, your function should not have any side effects and could be run
+       * many times per second.
+       *
+       * ```ts
+       * const getChildren = $el => $el.children()
+       *
+       * cy.pipe(getChildren)
+       *   .should('have.length', 3)
+       * ```
+       */
+      pipe<S extends object | any[] | string | number | boolean | undefined | null>(
+        fn: (this: { [key: string]: any }, currentSubject: JQuery) => S,
         options?: Partial<Timeoutable & Loggable>,
       ): Chainable<S>
     }

--- a/index.js
+++ b/index.js
@@ -62,7 +62,12 @@ function formatArg (arg) {
   }
 }
 
-Cypress.Commands.add('pipe', { prevSubject: true }, (subject, fn, options = { }) => {
+Cypress.Commands.add('pipe', { prevSubject: 'optional' }, (subject, fn, options = { }) => {
+
+  // Support https://github.com/NicholasBoll/cypress-pipe/issues/22
+  if (!subject) {
+    subject = Cypress.$('body')
+  }
 
   // if (isJquery(subject)) {
   //   patchJQueryForSelectorProperty(subject);


### PR DESCRIPTION
* Fixes #22

Adds ability to start a Cypress chain where the previous subject will be the body element. This is helpful for using a piped function that is meant for an element to not scope to some container element.

This allows the folowing:
```ts
const getChildren = $el => $el.children()

cy.pipe(getChildren)
  .should('have.length', 3)
```